### PR TITLE
fix: support comma separated files input

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -28,7 +28,14 @@ jobs:
           wget https://raw.githubusercontent.com/ublue-os/packages/main/staging/devpod/devpod.spec
           wget https://raw.githubusercontent.com/ublue-os/packages/main/staging/prompt/prompt.spec
 
-      - name: Test rpmlint
+      - name: Test rpmlint (single file)
         uses: ./
         with:
           rpmfiles: ./devpod.spec
+          permissive: 'true'
+
+      - name: Test rpmlint (multiple files)
+        uses: ./
+        with:
+          rpmfiles: './devpod.spec, ./prompt.spec'
+          permissive: 'true'

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Fetch spec
         run: |
           wget https://raw.githubusercontent.com/ublue-os/packages/main/staging/devpod/devpod.spec
+          wget https://raw.githubusercontent.com/ublue-os/packages/main/staging/prompt/prompt.spec
 
       - name: Test rpmlint
         uses: ./

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,5 +1,11 @@
 name: Test Action
 on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
   push:
     branches:
       - main

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -38,10 +38,8 @@ jobs:
         uses: ./
         with:
           rpmfiles: ./devpod.spec
-          permissive: 'true'
 
       - name: Test rpmlint (multiple files)
         uses: ./
         with:
           rpmfiles: './devpod.spec, ./prompt.spec'
-          permissive: 'true'

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ author: 'EyeCantCU'
 description: 'Checks for errors in RPMs via rpmlint'
 inputs:
   rpmfiles:
-    description: 'Files to be validated by rpmlint'
+    description: 'Comma-separated list of files to be validated by rpmlint'
     required: false
   help:
     description: 'Show help message and exit'

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,3 +1,3 @@
 FROM quay.io/fedora/fedora-minimal:39 AS rpmlint-action
 
-RUN dnf5 install -y rpmlint
+RUN dnf5 install -y rpmlint && dnf5 clean all

--- a/rpmlint.sh
+++ b/rpmlint.sh
@@ -20,7 +20,7 @@ if [[ -n "${PERMISSIVE}" ]]; then ARGUMENTS+=" -p "; fi
 # Format arguments
 ARGUMENTS=$(echo "$ARGUMENTS" | xargs)
 
-# Perform rpmlint on comma-separated list of files (RPMFILES)
+# Perform rpmlint on comma-separated list of files
 if [[ -n "${RPMFILES}" ]]; then
   for FILE in $(echo "${RPMFILES}" | tr "," "\n"); do
     rpmlint $ARGUMENTS $FILE

--- a/rpmlint.sh
+++ b/rpmlint.sh
@@ -20,9 +20,11 @@ if [[ -n "${PERMISSIVE}" ]]; then ARGUMENTS+=" -p "; fi
 # Format arguments
 ARGUMENTS=$(echo "$ARGUMENTS" | xargs)
 
-# Perform rpmlint
+# Perform rpmlint on comma-separated list of files (RPMFILES)
 if [[ -n "${RPMFILES}" ]]; then
-  rpmlint $ARGUMENTS ${RPMFILES[@]}
+  for FILE in $(echo "${RPMFILES}" | tr "," "\n"); do
+    rpmlint $ARGUMENTS $FILE
+  done
 else
   rpmlint $ARGUMENTS
 fi


### PR DESCRIPTION
You are not able to pass in multiple lines to GITHUB_ENV, so this changes the action to support comma-separated list of inputs instead.  

Added a `clean` step to the Containerfile to remove cache as this does not need to be distributed with the image.

Added a new spec file to the test workflow to validate if the changes in this PR work as expected.